### PR TITLE
Fixed PreferenceService Crash.

### DIFF
--- a/enabler/src/com/openxc/enabler/preferences/FileRecordingPreferenceManager.java
+++ b/enabler/src/com/openxc/enabler/preferences/FileRecordingPreferenceManager.java
@@ -70,7 +70,9 @@ public class FileRecordingPreferenceManager extends VehiclePreferenceManager {
     }
 
     private void stopRecording() {
-        getVehicleManager().removeSink(mFileRecorder);
-        mFileRecorder = null;
+    	if(getVehicleManager() != null){
+	        getVehicleManager().removeSink(mFileRecorder);
+	        mFileRecorder = null;
+    	}
     }
 }

--- a/enabler/src/com/openxc/enabler/preferences/GpsOverwritePreferenceManager.java
+++ b/enabler/src/com/openxc/enabler/preferences/GpsOverwritePreferenceManager.java
@@ -22,8 +22,10 @@ public class GpsOverwritePreferenceManager extends VehiclePreferenceManager {
 
     public void close() {
         super.close();
-        getVehicleManager().removeSink(mMockedLocationSink);
-        mMockedLocationSink = null;
+        if(getVehicleManager() != null){
+	        getVehicleManager().removeSink(mMockedLocationSink);
+	        mMockedLocationSink = null;
+        }
     }
 
     protected PreferenceListener createPreferenceListener(){

--- a/enabler/src/com/openxc/enabler/preferences/NativeGpsPreferenceManager.java
+++ b/enabler/src/com/openxc/enabler/preferences/NativeGpsPreferenceManager.java
@@ -52,7 +52,9 @@ public class NativeGpsPreferenceManager extends VehiclePreferenceManager {
     }
 
     private void stopNativeGps() {
-        getVehicleManager().removeSource(mNativeLocationSource);
-        mNativeLocationSource = null;
+    	if(getVehicleManager() != null){
+	        getVehicleManager().removeSource(mNativeLocationSource);
+	        mNativeLocationSource = null;
+    	}
     }
 }

--- a/enabler/src/com/openxc/enabler/preferences/TraceSourcePreferenceManager.java
+++ b/enabler/src/com/openxc/enabler/preferences/TraceSourcePreferenceManager.java
@@ -73,7 +73,9 @@ public class TraceSourcePreferenceManager extends VehiclePreferenceManager {
     }
 
     private synchronized void stopTrace() {
-        getVehicleManager().removeSource(mTraceSource);
-        mTraceSource = null;
+    	if(getVehicleManager() != null){
+	        getVehicleManager().removeSource(mTraceSource);
+	        mTraceSource = null;
+    	}
     }
 }

--- a/enabler/src/com/openxc/enabler/preferences/UploadingPreferenceManager.java
+++ b/enabler/src/com/openxc/enabler/preferences/UploadingPreferenceManager.java
@@ -79,7 +79,9 @@ public class UploadingPreferenceManager extends VehiclePreferenceManager {
     }
 
     private void stopUploading() {
-        getVehicleManager().removeSink(mUploader);
-        mUploader = null;
+    	if(getVehicleManager() != null){
+	        getVehicleManager().removeSink(mUploader);
+	        mUploader = null;
+    	}
     }
 }


### PR DESCRIPTION
Added a null check to getVehicleManager() method in individual Preference Managers when closing. This prevents a null pointer crash when the VehicleManager service finishes disposal prior to the PreferenceManager service.
