### PR TITLE
Removed stopping of services on Enabler Activity dispose.

### DIFF
--- a/enabler/src/com/openxc/enabler/OpenXcEnablerActivity.java
+++ b/enabler/src/com/openxc/enabler/OpenXcEnablerActivity.java
@@ -132,17 +132,6 @@ public class OpenXcEnablerActivity extends Activity {
     public void onDestroy() {
         super.onDestroy();
 
-        if(!stopService(new Intent(this, PreferenceManagerService.class))) {
-            Log.i(TAG, "Could not stop " +
-                        PreferenceManagerService.class.getSimpleName()
-                     + ". Service may not have been started.");
-        }
-
-        if(!stopService(new Intent(this, VehicleManager.class))) {
-            Log.i(TAG, "Could not stop " + VehicleManager.class.getSimpleName()
-                     + ". Service may not have been started.");
-        }
-
         Log.d(TAG, "Destroying Enabler activity");
     }
 


### PR DESCRIPTION
To enhance user experience, stopping of Preference and VehicleManager services in the onDispose() method of the EnablerActivity have been removed. 

Previously, if a user entered and exited the app quickly, there was a noticeable delay (10 to 30 seconds) before the services were restarted and rebound. 
