### PR TITLE
Caught NoSuchMethodError around BluetoothSocket.isConnected() call.

### DIFF
--- a/openxc/src/com/openxc/interfaces/bluetooth/BluetoothVehicleInterface.java
+++ b/openxc/src/com/openxc/interfaces/bluetooth/BluetoothVehicleInterface.java
@@ -78,8 +78,6 @@ public class BluetoothVehicleInterface extends BytestreamDataSource
     @Override
     public boolean isConnected() {
         mConnectionLock.readLock().lock();
-        //boolean connected = mSocket != null && mSocket.isConnected() &&
-           super.isConnected();
         
         boolean connected = mSocket != null && super.isConnected();
         


### PR DESCRIPTION
To determine if a BluetoothVehicleInterface is connected, ensure that mSocket is not null and that the superclass is connected. 

If BluetoothSocket.isConnected() is support it, otherwise skip by form of a try, catch. 
