### PR TITLE
Auto-connect Bluetooth

### DIFF
--- a/enabler/src/com/openxc/enabler/preferences/BluetoothPreferenceManager.java
+++ b/enabler/src/com/openxc/enabler/preferences/BluetoothPreferenceManager.java
@@ -17,7 +17,7 @@ import com.openxc.interfaces.bluetooth.BluetoothVehicleInterface;
 public class BluetoothPreferenceManager extends VehiclePreferenceManager {
     private final static String TAG = "BluetoothPreferenceManager";
     
-    private final static String OPENXC_VI_PREFIX = "OpenXC";
+    private final static String OPENXC_VI_PREFIX = "OpenXC-VI-";
 
     public BluetoothPreferenceManager(Context context) {
         super(context);


### PR DESCRIPTION
Modified Bluetooth Preference Manager to automatically connect to a Bluetooth device with the name "OpenXC-VI-*". 

Any device selected by the user will override the automatically connected device. 
When the device is automatically selected for connection, it will appear in the preference screen as the selected device. 
