### PR TITLE
Dpad menu

### DIFF
--- a/enabler/src/com/openxc/enabler/OpenXcEnablerActivity.java
+++ b/enabler/src/com/openxc/enabler/OpenXcEnablerActivity.java
@@ -17,7 +17,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.openxc.VehicleManager;
 import com.openxc.enabler.preferences.PreferenceManagerService;


### PR DESCRIPTION
This allows use of the menu on devices like the Recon Instruments MOD Live.

It's older than Android 2.3, so the OS requires use of the menu button to access the menu, but the MOD has no menu button.

This branch detects the directional buttons on the DPad (The MOD Live's single input device) and reacts by bringing up the menu.  

This doesn't seem to interfere with usual use, as the main Enabler activity has only the one button.
