### PR TITLE
Make command keys match command responses.

### DIFF
--- a/openxc/src/com/openxc/messages/CommandResponse.java
+++ b/openxc/src/com/openxc/messages/CommandResponse.java
@@ -74,7 +74,7 @@ public class CommandResponse extends KeyedMessage {
     @Override
     public MessageKey getKey() {
         HashMap<String, Object> key = new HashMap<>();
-        key.put(COMMAND_RESPONSE_KEY, getCommand());
+        key.put(Command.COMMAND_KEY, getCommand());
         return new MessageKey(key);
     }
 


### PR DESCRIPTION
Keys for commands and command responses only match if they have the same pair, and the key of a CommandResponse has in its pair a key  of 'command_response' instead of 'command' before this fix.
