### PR TITLE
Efficient MessageListenerSink

### DIFF
--- a/openxc/src/com/openxc/sinks/MessageListenerSink.java
+++ b/openxc/src/com/openxc/sinks/MessageListenerSink.java
@@ -55,7 +55,7 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             mPersistentListeners.remove(listener);
         }
         
-        void removeAllSingular() {
+        void removeAllNonPersistent() {
             mListeners = new ArrayList<>();
         }
         
@@ -159,7 +159,7 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             }
 
             for (KeyMatcher matcher : matchedKeys) {
-                mMessageListeners.get(matcher).removeAllSingular();
+                mMessageListeners.get(matcher).removeAllNonPersistent();
             }
 
             if (message instanceof SimpleVehicleMessage) {

--- a/openxc/src/com/openxc/sinks/MessageListenerSink.java
+++ b/openxc/src/com/openxc/sinks/MessageListenerSink.java
@@ -55,10 +55,6 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             mPersistentListeners.remove(listener);
         }
         
-        void removeAllNonPersistent() {
-            mListeners = new ArrayList<>();
-        }
-        
         void receive(VehicleMessage message) {
             for (VehicleMessage.Listener listener : mPersistentListeners) {
                 listener.receive(message);
@@ -66,6 +62,7 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             for (VehicleMessage.Listener listener : mListeners) {
                 listener.receive(message);
             }   
+            mListeners = new ArrayList<>(); //delete all non-persistent
         }
         
         boolean isEmpty() {
@@ -178,7 +175,6 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             }
 
             for (KeyMatcher matcher : matchedKeys) {
-                mMessageListeners.get(matcher).removeAllNonPersistent();
                 pruneListeners(matcher);
             }
             

--- a/openxc/src/com/openxc/sinks/MessageListenerSink.java
+++ b/openxc/src/com/openxc/sinks/MessageListenerSink.java
@@ -31,14 +31,14 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
 
     // The non-persistent listeners will be removed after they receive their
     // first message.
-    private Map<KeyMatcher, ListenerGroup>
+    private Map<KeyMatcher, MessageListenerGroup>
             mMessageListeners = new HashMap<>();
     private Multimap<Class<? extends Measurement>, Measurement.Listener>
             mMeasurementTypeListeners = HashMultimap.create();
     private Multimap<Class<? extends VehicleMessage>, VehicleMessage.Listener>
             mMessageTypeListeners = HashMultimap.create();
 
-    private class ListenerGroup {
+    private class MessageListenerGroup {
         
         ArrayList<VehicleMessage.Listener> mPersistentListeners = new ArrayList<>();
         ArrayList<VehicleMessage.Listener> mListeners = new ArrayList<>();
@@ -68,9 +68,9 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
     public synchronized void register(KeyMatcher matcher,
             VehicleMessage.Listener listener, boolean persist) {
        
-        ListenerGroup group = mMessageListeners.get(matcher);
+        MessageListenerGroup group = mMessageListeners.get(matcher);
         if (group == null) {
-            group = new ListenerGroup();
+            group = new MessageListenerGroup();
             mMessageListeners.put(matcher, group);
         }
         
@@ -148,7 +148,7 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             Set<KeyMatcher> matchedKeys = new HashSet<>();
             for (KeyMatcher matcher : mMessageListeners.keySet()) {
                 if (matcher.matches(message.asKeyedMessage())) {
-                    ListenerGroup group = mMessageListeners.get(matcher);
+                    MessageListenerGroup group = mMessageListeners.get(matcher);
                     for (VehicleMessage.Listener listener : group.mPersistentListeners) {
                         listener.receive(message);
                     }

--- a/openxc/src/com/openxc/sinks/MessageListenerSink.java
+++ b/openxc/src/com/openxc/sinks/MessageListenerSink.java
@@ -59,6 +59,15 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             mListeners = new ArrayList<>();
         }
         
+        void receive(VehicleMessage message) {
+            for (VehicleMessage.Listener listener : mPersistentListeners) {
+                listener.receive(message);
+            }
+            for (VehicleMessage.Listener listener : mListeners) {
+                listener.receive(message);
+            }   
+        }
+        
         boolean isEmpty() {
             return mPersistentListeners.isEmpty() && mListeners.isEmpty();
         }   
@@ -140,7 +149,6 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
     }
     
     private int getNumPersistentListeners() {
-        
         int sum = 0;
         for (KeyMatcher matcher : mMessageListeners.keySet()) {
             sum += mMessageListeners.get(matcher).mPersistentListeners.size();
@@ -164,12 +172,8 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
             for (KeyMatcher matcher : mMessageListeners.keySet()) {
                 if (matcher.matches(message.asKeyedMessage())) {
                     MessageListenerGroup group = mMessageListeners.get(matcher);
-                    for (VehicleMessage.Listener listener : group.mPersistentListeners) {
-                        listener.receive(message);
-                    }
-                    for (VehicleMessage.Listener listener : group.mListeners) {
-                        listener.receive(message);
-                    }
+                    group.receive(message);
+                    matchedKeys.add(matcher);
                 }
             }
 

--- a/openxc/src/com/openxc/sinks/MessageListenerSink.java
+++ b/openxc/src/com/openxc/sinks/MessageListenerSink.java
@@ -151,7 +151,7 @@ public class MessageListenerSink extends AbstractQueuedCallbackSink {
     
     private void pruneListeners(KeyMatcher matcher) {
         MessageListenerGroup group = mMessageListeners.get(matcher);
-        if (group.isEmpty()) {
+        if (group != null && group.isEmpty()) {
             mMessageListeners.remove(matcher);
         }
     }


### PR DESCRIPTION
A possible solution to #200 .  A bit more code for managing the listeners and their registrations but I think worth it for the performance gain in propagateMessage(VehicleMessage).