### PR TITLE
Update .gitignore For SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ release.properties
 release
 tokens.xml
 local.properties
+.scannerwork/
 
 # Built application files
 *.apk


### PR DESCRIPTION
### Changes
- Update .gitignore to ignore `.scannerwork` folder