### PR TITLE
Fix SonarQube Null & Instance Issues

### DIFF
--- a/enabler/build.gradle
+++ b/enabler/build.gradle
@@ -59,6 +59,7 @@ android {
 
     lintOptions {
         abortOnError false
+        disable 'LongLogTag'
     }
 
     packagingOptions {

--- a/enabler/src/main/java/com/openxc/enabler/VehicleMessageAdapter.java
+++ b/enabler/src/main/java/com/openxc/enabler/VehicleMessageAdapter.java
@@ -13,8 +13,6 @@ import com.openxc.messages.VehicleMessage;
 
 public abstract class VehicleMessageAdapter extends BaseAdapter {
     protected List<VehicleMessage> mValues = new ArrayList<>();
-    private static SimpleDateFormat sDateFormatter =
-            new SimpleDateFormat( "HH:mm:ss.S", Locale.US);
 
     public void add(VehicleMessage message) {
         ThreadPreconditions.checkOnMainThread();
@@ -26,6 +24,8 @@ public abstract class VehicleMessageAdapter extends BaseAdapter {
 
     protected static String formatTimestamp(VehicleMessage message) {
         if(message.isTimestamped()) {
+            SimpleDateFormat sDateFormatter =
+                    new SimpleDateFormat( "HH:mm:ss.S", Locale.US);
             return sDateFormatter.format(message.getDate());
         }
         return "";

--- a/enabler/src/main/java/com/openxc/enabler/preferences/VehiclePreferenceManager.java
+++ b/enabler/src/main/java/com/openxc/enabler/preferences/VehiclePreferenceManager.java
@@ -32,7 +32,11 @@ public abstract class VehiclePreferenceManager {
     public void setVehicleManager(VehicleManager vehicle) {
         mVehicle = vehicle;
         mPreferenceListener = watchPreferences(getPreferences());
-        mPreferenceListener.readStoredPreferences();
+        if (mPreferenceListener != null) {
+            mPreferenceListener.readStoredPreferences();
+        } else {
+            Log.w(TAG, "mPreferenceListener was null");
+        }
     }
 
     /**

--- a/library/src/main/java/com/buglabs/dweetlib/DweetLib.java
+++ b/library/src/main/java/com/buglabs/dweetlib/DweetLib.java
@@ -147,7 +147,9 @@ public class DweetLib {
                 if (caller!=null) {
                     ArrayList ar = new ArrayList<>();
                     ar.add(CONNECTION_ERROR);
-                    cb.callback(ar);
+                    if (cb != null) {
+                        cb.callback(ar);
+                    }
                 }
                 DweetTask x = (DweetTask)thingProcessUrl.get(urlstr);
                 thingProcessUrl.remove(urlstr);

--- a/library/src/main/java/com/openxc/sinks/FileRecorderSink.java
+++ b/library/src/main/java/com/openxc/sinks/FileRecorderSink.java
@@ -27,8 +27,6 @@ import com.openxc.util.FileOpener;
 public class FileRecorderSink implements VehicleDataSink {
     private final static String TAG = "FileRecorderSink";
     private final static int INTER_TRIP_THRESHOLD_MINUTES = 5;
-    private static SimpleDateFormat sDateFormatter =
-            new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US);
 
     private FileOpener mFileOpener;
     private BufferedWriter mWriter;
@@ -97,6 +95,8 @@ public class FileRecorderSink implements VehicleDataSink {
 
     private synchronized void openTimestampedFile() throws IOException {
         Calendar calendar = Calendar.getInstance();
+        SimpleDateFormat sDateFormatter =
+                new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US);
         String filename = sDateFormatter.format(
                 calendar.getTime()) + ".json";
         if(mWriter != null) {


### PR DESCRIPTION
### Changes
- Fixed 2 areas where we weren't checking for null and a `NullPointerException` could be thrown
- Fixed 2 uses of `SimpleDateFormat` being used as a static variable
    - They are now used within the calling methods as instance variables
    - This needed to be addressed as `SimpleDateFormat` is not thread-safe
