### PR TITLE
Handle Interrupted Exceptions

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,6 +16,7 @@ android {
 
     lintOptions {
         abortOnError false
+        disable 'LongLogTag'
     }
     useLibrary  'org.apache.http.legacy'
 }

--- a/library/src/main/java/com/openxc/interfaces/bluetooth/BluetoothVehicleInterface.java
+++ b/library/src/main/java/com/openxc/interfaces/bluetooth/BluetoothVehicleInterface.java
@@ -178,6 +178,9 @@ public class BluetoothVehicleInterface extends BytestreamDataSource
                 mConnectionLock.readLock().unlock();
             }
         } catch (InterruptedException e) {
+            Log.w(TAG, "Interrupted...");
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
 
         return connected;
@@ -221,7 +224,9 @@ public class BluetoothVehicleInterface extends BytestreamDataSource
                     try {
                         mDeviceChanged.await();
                     } catch (InterruptedException e) {
-
+                        Log.w(TAG, "Interrupted...");
+                        e.printStackTrace();
+                        Thread.currentThread().interrupt();
                     } finally {
                         mConnectionLock.writeLock().unlock();
                     }

--- a/library/src/main/java/com/openxc/interfaces/bluetooth/DeviceManager.java
+++ b/library/src/main/java/com/openxc/interfaces/bluetooth/DeviceManager.java
@@ -361,8 +361,9 @@ public class DeviceManager {
                             Thread.sleep(PACKET_SENDING_WAIT_TIME_MS);
 
                         } catch (InterruptedException e) {
-                            Log.d(TAG, "Interrupted");
+                            Log.d(TAG, "Interrupted...");
                             e.printStackTrace();
+                            Thread.currentThread().interrupt();
                         }
                         mBluetoothGatt.writeCharacteristic(characteristic);
                     }

--- a/library/src/main/java/com/openxc/interfaces/network/NetworkVehicleInterface.java
+++ b/library/src/main/java/com/openxc/interfaces/network/NetworkVehicleInterface.java
@@ -123,7 +123,11 @@ public class NetworkVehicleInterface extends BytestreamDataSource
                 connected = mSocket != null && mSocket.isConnected() && super.isConnected();
                 mConnectionLock.readLock().unlock();
             }
-        } catch(InterruptedException e) {}
+        } catch(InterruptedException e) {
+            Log.d(TAG, "Interrupted...");
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
+        }
         return connected;
     }
 

--- a/library/src/main/java/com/openxc/sinks/AbstractQueuedCallbackSink.java
+++ b/library/src/main/java/com/openxc/sinks/AbstractQueuedCallbackSink.java
@@ -60,6 +60,9 @@ public abstract class AbstractQueuedCallbackSink implements VehicleDataSink {
                 mNotificationsChanged.await();
             }
         } catch(InterruptedException e) {
+            Log.w(TAG, "Interrupted...");
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
         } finally {
             mNotificationsLock.unlock();
         }
@@ -108,6 +111,8 @@ public abstract class AbstractQueuedCallbackSink implements VehicleDataSink {
                 } catch(InterruptedException e) {
                     Log.d(TAG, "Interrupted while waiting for a new " +
                             "item for notification -- likely shutting down");
+                    e.printStackTrace();
+                    Thread.currentThread().interrupt();
                     break;
                 } finally {
                     mNotificationsChanged.signal();

--- a/library/src/main/java/com/openxc/sinks/DweetSink.java
+++ b/library/src/main/java/com/openxc/sinks/DweetSink.java
@@ -96,6 +96,8 @@ public class DweetSink extends ContextualVehicleDataSink {
                     records = getRecords();
                 } catch(InterruptedException e) {
                     Log.w(TAG, "Dweeter was interrupted", e);
+                    e.printStackTrace();
+                    Thread.currentThread().interrupt();
                     break;
                 }
             }

--- a/library/src/main/java/com/openxc/sinks/UploaderSink.java
+++ b/library/src/main/java/com/openxc/sinks/UploaderSink.java
@@ -155,6 +155,8 @@ public class UploaderSink extends ContextualVehicleDataSink {
                     Log.w(TAG, "Problem uploading the record", e);
                 } catch(InterruptedException e) {
                     Log.w(TAG, "Uploader was interrupted", e);
+                    e.printStackTrace();
+                    Thread.currentThread().interrupt();
                     break;
                 }
             }

--- a/library/src/main/java/com/openxc/sources/BaseVehicleDataSource.java
+++ b/library/src/main/java/com/openxc/sources/BaseVehicleDataSource.java
@@ -1,5 +1,7 @@
 package com.openxc.sources;
 
+import android.util.Log;
+
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -98,6 +100,9 @@ public abstract class BaseVehicleDataSource implements VehicleDataSource {
                 mCallbackChanged.await();
             }
         } catch(InterruptedException e) {
+            Log.w(TAG, "Interrupted...");
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
         } finally {
             mCallbackLock.unlock();
         }

--- a/library/src/main/java/com/openxc/sources/BytestreamDataSource.java
+++ b/library/src/main/java/com/openxc/sources/BytestreamDataSource.java
@@ -140,6 +140,8 @@ public abstract class BytestreamDataSource extends ContextualVehicleDataSource
             } catch(InterruptedException e) {
                 Log.i(getTag(), "Interrupted while waiting for connection - stopping the source");
                 stop();
+                e.printStackTrace();
+                Thread.currentThread().interrupt();
                 break;
             }
 

--- a/library/src/main/java/com/openxc/sources/TestSource.java
+++ b/library/src/main/java/com/openxc/sources/TestSource.java
@@ -1,5 +1,7 @@
 package com.openxc.sources;
 
+import android.util.Log;
+
 import com.openxc.messages.SimpleVehicleMessage;
 import com.openxc.messages.VehicleMessage;
 
@@ -24,7 +26,11 @@ public class TestSource extends BaseVehicleDataSource {
                 // our assertions
                 try {
                     Thread.sleep(1000);
-                } catch(InterruptedException e) {}
+                } catch(InterruptedException e) {
+                    Log.w("BaseVehicleDataSource", "Interrupted...");
+                    e.printStackTrace();
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }

--- a/library/src/main/java/com/openxc/sources/trace/TraceVehicleDataSource.java
+++ b/library/src/main/java/com/openxc/sources/trace/TraceVehicleDataSource.java
@@ -237,6 +237,9 @@ public class TraceVehicleDataSource extends ContextualVehicleDataSource
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
                     mRunning = false;
+                    Log.w(TAG, "Interrupted...");
+                    e.printStackTrace();
+                    Thread.currentThread().interrupt();
                 }
             }
             disconnected();
@@ -320,7 +323,11 @@ public class TraceVehicleDataSource extends ContextualVehicleDataSource
         long sleepDuration = Math.max(targetTime - System.currentTimeMillis(), 0);
         try {
             Thread.sleep(sleepDuration);
-        } catch(InterruptedException e) {}
+        } catch(InterruptedException e) {
+            Log.w(TAG, "Interrupted...");
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
+        }
     }
 
     private BufferedReader openResourceFile(URI filename) {


### PR DESCRIPTION
### Changes
- Invoke `Thread.currentThread().interrupt()` whenever an `InterruptException` is caught
- Log the interrupt in places where the exception was just swallowed
- Add a finally to `VehicleManager` where the `InterruptException` was to make to unlock `mRemoteBoundLock`

### Notes
By searching online, found out that a thread should handle the exception in this way as to set it's interrupt flag. This is just to let high level methods know that the thread may terminate and allow the higher level to handle it if needed. As a general rule, we shouldn't just swallow.

> This is done to keep state.
> When you catch the InterruptException and swallow it, you essentially prevent any higher level methods/thread groups from noticing the interrupt. Which may cause problems.
> By calling Thread.currentThread().interrupt(), you set the interrupt flag of the thread, so higher level interrupt handlers will notice it and can handle it appropriately.

> Only code that implements a thread's interruption policy may swallow an interruption request.
> General-purpose task and library code should never swallow interruption requests.

[Reference](https://stackoverflow.com/questions/4906799/why-invoke-thread-currentthread-interrupt-in-a-catch-interruptexception-block)