### PR TITLE
Linking project overview dashboard to README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -2,6 +2,7 @@ OpenXC Android Library
 =========================
 
 [![Build Status](https://travis-ci.org/openxc/openxc-android.svg?branch=master)](https://travis-ci.org/openxc/openxc-android)
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/openxcopenxcandroid/)
 
 This library is a part of the [OpenXC](http://openxcplatform.com) project.
 


### PR DESCRIPTION
Adding a link to the README header. The linked dashboard describes overall repository structure. The goal is to help new developers explore project and understand architecture/dependencies. Direct link: https://sourcespy.com/github/openxcopenxcandroid/