### PR TITLE
Fix Dashboard Crashes

### DIFF
--- a/library/src/test/java/com/openxc/BaseMeasurementTest.java
+++ b/library/src/test/java/com/openxc/BaseMeasurementTest.java
@@ -119,6 +119,12 @@ public class BaseMeasurementTest {
         BaseMeasurement.getMeasurementFromMessage(VehicleSpeed.class, null);
     }
 
+    @Test(expected=UnrecognizedMeasurementTypeException.class)
+    public void testForUnrecognizedMeasurementTypeException() throws UnrecognizedMeasurementTypeException, NoValueException {
+        SimpleVehicleMessage message = new SimpleVehicleMessage(0L, "door_status", "rear_left: false");
+        Measurement measurement = BaseMeasurement.getMeasurementFromMessage(VehicleDoorStatus.class, message);
+    }
+
     @Test
     public void buildEventedFromMessage()
             throws UnrecognizedMeasurementTypeException, NoValueException {


### PR DESCRIPTION
### Changes
- Revert refactoring changes for `BaseMeasurement.java`
- Added test to ensure check for the exception that should have been thrown

### Notes
Previously button event messages were crashing when switching to the dashboard view in the application. Turns out the conversion from `SimpleVehicleMessage` to `Measurement` was failing for the message with button and door events.