### PR TITLE
File storage fix

### DIFF
--- a/enabler/src/main/AndroidManifest.xml
+++ b/enabler/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
       android:name="com.openxc.enabler.OpenXCApplication"
       android:allowBackup="true"
       android:icon="@mipmap/ic_launcher"
+      android:requestLegacyExternalStorage="true"
       android:label="@string/app_name"
       android:theme="@android:style/Theme.Holo">
 

--- a/library/src/main/java/com/openxc/VehicleLocationProvider.java
+++ b/library/src/main/java/com/openxc/VehicleLocationProvider.java
@@ -201,7 +201,7 @@ public class VehicleLocationProvider implements Measurement.Listener {
             if(mLocationManager.getProvider(
                         VEHICLE_LOCATION_PROVIDER) == null) {
                 mLocationManager.addTestProvider(VEHICLE_LOCATION_PROVIDER,
-                        false, false, false, false, false, true, false, 0, 5);
+                        false, false, false, false, false, true, false, 1, 2);
             }
             mLocationManager.setTestProviderEnabled(
                     VEHICLE_LOCATION_PROVIDER, true);


### PR DESCRIPTION
Request two code changes:
1) In Android Manifest, add `android:requestLegacyExternalStorage="true"`, which enables the trace file to correctly write to the Android host device for newer Android versions.

2) In **VehicleLocationProvider.java**, modify `powerRequirement` and `accuracy` values for adding a test provider. The existing values cause the application to crash, while the proposed values worked for me.

These two modifications were tested on:
* (Physical device) LG G Pad X II 10.1 Tablet, running Android 6.0.1
* Android Studio AVD, Pixel 3a API 29
* (Physical device) Pixel 3a, running Android 11